### PR TITLE
Update rm.js

### DIFF
--- a/packages/git/examples/rm.js
+++ b/packages/git/examples/rm.js
@@ -1,5 +1,3 @@
-const fs = require('fs');
-
 const { rm } = require('../src');
 
 async function main() {


### PR DESCRIPTION
Removed a line that requires `fs` as it's not needed in the git `rm` example.