### PR TITLE
Add removeField and removeScript methods

### DIFF
--- a/packages/package-json/README.md
+++ b/packages/package-json/README.md
@@ -27,6 +27,7 @@ Methods returned:
 - [writeChanges](#writeChanges)
 - [getField](#getField)
 - [setField](#setField)
+- [removeField](#removeField)
 - [requireDependency](#requireDependency)
 - [removeDependency](#removeDependency)
 - [requireScript](#requireScript)
@@ -82,6 +83,26 @@ Returns a changelog entry object:
   "meta": {},
   "previousValue": "oldName",
   "alreadyExisted": false
+}
+```
+
+### removeField
+
+Removes a specific field in the `package.json` object and returns a changelog entry.
+
+```javascript
+packageJson.removeField("license");
+```
+
+Returns a changelog entry object:
+
+```json
+{
+  "event": "removeField",
+  "field": "license",
+  "meta": {},
+  "previousValue": "MIT",
+  "alreadyExisted": true
 }
 ```
 

--- a/packages/package-json/README.md
+++ b/packages/package-json/README.md
@@ -31,6 +31,7 @@ Methods returned:
 - [requireDependency](#requireDependency)
 - [removeDependency](#removeDependency)
 - [requireScript](#requireScript)
+- [removeScript](#removeScript)
 - [getChangelog](#getChangelog)
 
 ### get
@@ -178,6 +179,29 @@ Returns a changelog entry object:
   "field": "scripts",
   "meta": {
     "stage": "test"
+  },
+  "alreadyExisted": true
+}
+```
+
+### removeScript
+
+Requires a script to exist in the `scripts` field of `package.json`.
+
+```javascript
+packageJson.removeScript({
+  stage: "lint"
+});
+```
+
+Returns a changelog entry object:
+
+```json
+{
+  "event": "removeScript",
+  "field": "scripts",
+  "meta": {
+    "stage": "lint"
   },
   "alreadyExisted": true
 }

--- a/packages/package-json/README.md
+++ b/packages/package-json/README.md
@@ -50,7 +50,6 @@ Checks if there are file changes to write.
 packageJson.hasChangesToWrite(); // true or false
 ```
 
-
 ### writeChanges
 
 Writes to the `package.json` file.

--- a/packages/package-json/src/index.js
+++ b/packages/package-json/src/index.js
@@ -212,9 +212,9 @@ module.exports = function loadPackageJson(options = {}) {
 		const changes = { event: "requireDependency", field, pkg, version };
 
 		const dependencyAlreadyExists = typeof dependencies[pkg] !== "undefined";
-		changes.alreadyExisted = dependencyAlreadyExists;
 		if (dependencyAlreadyExists) {
 			changes.previousValue = dependencies[pkg];
+			changes.alreadyExisted = true;
 		}
 
 		dependencies[pkg] = version;
@@ -289,8 +289,7 @@ module.exports = function loadPackageJson(options = {}) {
 
 		const scripts = workingContents.scripts;
 
-		const stageAlreadyExists =
-			typeof scripts[stage] !== "undefined";
+		const stageAlreadyExists = typeof scripts[stage] !== "undefined";
 
 		changes.alreadyExisted = stageAlreadyExists;
 

--- a/packages/package-json/src/index.js
+++ b/packages/package-json/src/index.js
@@ -70,7 +70,8 @@ module.exports = function loadPackageJson(options = {}) {
 		removeField,
 		requireDependency,
 		removeDependency,
-		requireScript
+		requireScript,
+		removeScript
 	};
 
 	/**
@@ -294,6 +295,37 @@ module.exports = function loadPackageJson(options = {}) {
 		changes.alreadyExisted = stageAlreadyExists;
 
 		scripts[stage] = command;
+
+		return changelog.createEntry(changes);
+	}
+
+	/**
+	 * Remove a script from the `scripts` field of `package.json`.
+	 *
+	 * @see https://docs.npmjs.com/misc/scripts
+	 *
+	 * @param {object} options
+	 * @param {string} options.stage - e.g. start, test, build, deploy
+	 * @returns {object} - changelog entry
+	 */
+	function removeScript(stage) {
+		const changes = {
+			event: "removeScript",
+			field: "scripts",
+			stage
+		};
+
+		const scripts = workingContents.scripts;
+		const scriptsFieldExists = typeof scripts !== "undefined";
+		const stageExists =
+			scriptsFieldExists && typeof scripts[stage] !== "undefined";
+
+		if (!stageExists) {
+			return false;
+		}
+
+		delete scripts[stage];
+		changes.alreadyExisted = true;
 
 		return changelog.createEntry(changes);
 	}

--- a/packages/package-json/src/index.js
+++ b/packages/package-json/src/index.js
@@ -67,6 +67,7 @@ module.exports = function loadPackageJson(options = {}) {
 		writeChanges,
 		getField,
 		setField,
+		removeField,
 		requireDependency,
 		removeDependency,
 		requireScript
@@ -152,6 +153,32 @@ module.exports = function loadPackageJson(options = {}) {
 		}
 
 		workingContents[field] = value;
+
+		return changelog.createEntry(changes);
+	}
+
+	/**
+	 * Removes a specific field from the `package.json` object.
+	 *
+	 * @param {string} field
+	 * @returns {object} - changelog entry
+	 */
+	function removeField(field) {
+		const changes = {
+			event: "removeField",
+			field
+		};
+
+		const fieldExists = typeof workingContents[field] !== "undefined";
+
+		if (fieldExists) {
+			changes.previousValue = workingContents[field];
+			changes.alreadyExisted = true;
+		} else {
+			return false;
+		}
+
+		delete workingContents[field];
 
 		return changelog.createEntry(changes);
 	}

--- a/packages/package-json/src/lib/changelog/index.js
+++ b/packages/package-json/src/lib/changelog/index.js
@@ -3,6 +3,7 @@ const messageFormatters = require("./message-formatters");
 
 const changeEvents = [
 	"setField",
+	"removeField",
 	"requireDependency",
 	"removeDependency",
 	"requireScript"

--- a/packages/package-json/src/lib/changelog/index.js
+++ b/packages/package-json/src/lib/changelog/index.js
@@ -6,7 +6,8 @@ const changeEvents = [
 	"removeField",
 	"requireDependency",
 	"removeDependency",
-	"requireScript"
+	"requireScript",
+	"removeScript"
 ];
 
 module.exports = function createChangelog() {

--- a/packages/package-json/src/lib/changelog/message-formatters.js
+++ b/packages/package-json/src/lib/changelog/message-formatters.js
@@ -107,3 +107,18 @@ exports.requireScript = ({ alreadyExisted, meta }) => {
 	message += alreadyExisted ? ` (overwrote existing command)` : " (new script)";
 	return message;
 };
+
+/**
+ * Format a `removeScript` changelog entry object as a human-friendly message.
+ *
+ * @memberof messageFormatters
+ * @function removeScript
+ * @param {object} options
+ * @param {object} options.meta
+ * @param {string} options.meta.stage
+ * @returns {string}
+ */
+exports.removeScript = ({ meta }) => {
+	let message = `Removed script for stage '${meta.stage}'`;
+	return message;
+};

--- a/packages/package-json/src/lib/changelog/message-formatters.js
+++ b/packages/package-json/src/lib/changelog/message-formatters.js
@@ -41,6 +41,20 @@ exports.setField = ({ field, alreadyExisted }) => {
 };
 
 /**
+ * Format a `removeField` changelog entry object as a human-friendly message.
+ *
+ * @memberof messageFormatters
+ * @function removeField
+ * @param {object} options
+ * @param {string} options.field
+ * @returns {string}
+ */
+exports.removeField = ({ field }) => {
+	let message = `Removed field '${field}'`;
+	return message;
+};
+
+/**
  * Format a `requireDependency` changelog entry object as a human-friendly message.
  *
  * @memberof messageFormatters

--- a/packages/package-json/src/lib/changelog/message-formatters.js
+++ b/packages/package-json/src/lib/changelog/message-formatters.js
@@ -67,6 +67,7 @@ exports.removeField = ({ field }) => {
  * @param {string} options.meta.version
  * @returns {string}
  */
+
 exports.requireDependency = ({ field, previousValue = undefined, meta }) => {
 	let message = `Required package ${meta.pkg}@${meta.version} in ${field}`;
 	message += previousValue

--- a/packages/package-json/test/__snapshots__/index.test.js.snap
+++ b/packages/package-json/test/__snapshots__/index.test.js.snap
@@ -274,6 +274,77 @@ Object {
 }
 `;
 
+exports[`removeScript removes existing script if present 1`] = `
+Object {
+  "alreadyExisted": true,
+  "event": "removeScript",
+  "field": "scripts",
+  "meta": Object {
+    "stage": "test",
+  },
+}
+`;
+
+exports[`removeScript removes existing script if present 2`] = `
+Object {
+  "bin": "./bin/ebi.js",
+  "bugs": Object {
+    "url": "https://github.com/Financial-Times/ebi/issues",
+  },
+  "contributors": Array [
+    Object {
+      "email": "jennifer.johnson@ft.com",
+      "name": "Jennifer Johnson",
+    },
+    Object {
+      "email": "jennifer.shepherd@ft.com",
+      "name": "Jennifer Shepherd",
+    },
+    Object {
+      "email": "tak.tran@ft.com",
+      "name": "Tak Tran",
+    },
+  ],
+  "dependencies": Object {
+    "@octokit/plugin-throttling": "^2.4.0",
+    "@octokit/rest": "^16.15.0",
+    "lodash": "^4.17.11",
+    "nock": "^10.0.6",
+    "yargs": "^13.1.0",
+  },
+  "description": "A command line tool that searches files within GitHub repositories",
+  "devDependencies": Object {
+    "eslint": "^5.14.1",
+    "eslint-config-prettier": "^4.0.0",
+    "eslint-plugin-no-only-tests": "^2.1.0",
+    "husky": "^1.3.1",
+    "jest": "^24.1.0",
+    "prettier": "1.16.3",
+  },
+  "engines": Object {
+    "node": "10.15.0",
+  },
+  "homepage": "https://github.com/Financial-Times/ebi#readme",
+  "husky": Object {
+    "hooks": Object {
+      "pre-commit": "npm run lint",
+    },
+  },
+  "license": "MIT",
+  "name": "ebi",
+  "repository": Object {
+    "type": "git",
+    "url": "git+https://github.com/Financial-Times/ebi.git",
+  },
+  "scripts": Object {
+    "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
+    "lint": "eslint *.js src/ lib/ test/",
+    "lint-fix": "eslint --fix *.js src/ lib/ test/",
+  },
+  "version": "0.0.0",
+}
+`;
+
 exports[`requireDependency creates field and new dependency if both are absent 1`] = `
 Object {
   "alreadyExisted": false,

--- a/packages/package-json/test/__snapshots__/index.test.js.snap
+++ b/packages/package-json/test/__snapshots__/index.test.js.snap
@@ -204,6 +204,76 @@ Object {
 
 exports[`removeDependency throws error if \`field\` is not a valid field for dependencies 1`] = `"package-json#removeDependency: Invalid field specified 'testDependencies'. Valid fields: dependencies, devDependencies, optionalDependencies, peerDependencies"`;
 
+exports[`removeField removes the field if it exists 1`] = `
+Object {
+  "alreadyExisted": true,
+  "event": "removeField",
+  "field": "bugs",
+  "meta": Object {},
+  "previousValue": Object {
+    "url": "https://github.com/Financial-Times/ebi/issues",
+  },
+}
+`;
+
+exports[`removeField removes the field if it exists 2`] = `
+Object {
+  "bin": "./bin/ebi.js",
+  "contributors": Array [
+    Object {
+      "email": "jennifer.johnson@ft.com",
+      "name": "Jennifer Johnson",
+    },
+    Object {
+      "email": "jennifer.shepherd@ft.com",
+      "name": "Jennifer Shepherd",
+    },
+    Object {
+      "email": "tak.tran@ft.com",
+      "name": "Tak Tran",
+    },
+  ],
+  "dependencies": Object {
+    "@octokit/plugin-throttling": "^2.4.0",
+    "@octokit/rest": "^16.15.0",
+    "lodash": "^4.17.11",
+    "nock": "^10.0.6",
+    "yargs": "^13.1.0",
+  },
+  "description": "A command line tool that searches files within GitHub repositories",
+  "devDependencies": Object {
+    "eslint": "^5.14.1",
+    "eslint-config-prettier": "^4.0.0",
+    "eslint-plugin-no-only-tests": "^2.1.0",
+    "husky": "^1.3.1",
+    "jest": "^24.1.0",
+    "prettier": "1.16.3",
+  },
+  "engines": Object {
+    "node": "10.15.0",
+  },
+  "homepage": "https://github.com/Financial-Times/ebi#readme",
+  "husky": Object {
+    "hooks": Object {
+      "pre-commit": "npm run lint",
+    },
+  },
+  "license": "MIT",
+  "name": "ebi",
+  "repository": Object {
+    "type": "git",
+    "url": "git+https://github.com/Financial-Times/ebi.git",
+  },
+  "scripts": Object {
+    "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
+    "lint": "eslint *.js src/ lib/ test/",
+    "lint-fix": "eslint --fix *.js src/ lib/ test/",
+    "test": "npm run lint && npm run unit-test",
+  },
+  "version": "0.0.0",
+}
+`;
+
 exports[`requireDependency creates field and new dependency if both are absent 1`] = `
 Object {
   "alreadyExisted": false,

--- a/packages/package-json/test/index.test.js
+++ b/packages/package-json/test/index.test.js
@@ -246,3 +246,30 @@ describe("requireScript", () => {
 		expect(packageJson.get()).toMatchSnapshot();
 	});
 });
+
+describe("removeScript", () => {
+	test("returns boolean false if `scripts` does not exist", () => {
+		const packageJsonWithoutScripts = loadPackageJson({
+			filepath: `${__dirname}/fixtures/test-no-scripts-package.json`
+		});
+		const changelogEntry = packageJsonWithoutScripts.removeScript({
+			stage: "deploy"
+		});
+		expect(changelogEntry).toEqual(false);
+	});
+
+	test("returns boolean false if `stage` does not exist", () => {
+		const changelogEntry = packageJson.removeScript({
+			stage: "deploy"
+		});
+		expect(changelogEntry).toEqual(false);
+	});
+
+	test("removes existing script if present", () => {
+		const changelogEntry = packageJson.removeScript("test");
+		expect(changelogEntry).toMatchSnapshot();
+		expect(changelogEntry.alreadyExisted).toEqual(true);
+		expect(changelogEntry.meta.stage).toEqual("test");
+		expect(packageJson.get()).toMatchSnapshot();
+	});
+});

--- a/packages/package-json/test/index.test.js
+++ b/packages/package-json/test/index.test.js
@@ -103,6 +103,22 @@ describe("setField", () => {
 	});
 });
 
+describe("removeField", () => {
+	test("removes the field if it exists", () => {
+		const changelogEntry = packageJson.removeField("bugs");
+		expect(changelogEntry).toMatchSnapshot();
+		expect(packageJson.get()).toMatchSnapshot();
+	});
+
+	test("removeField returns boolean false if field does not exist", () => {
+		let newPackageJson = loadPackageJson({
+			filepath: `${__dirname}/fixtures/test-no-scripts-package.json`
+		});
+		const changelogEntry = newPackageJson.removeField("scripts");
+		expect(changelogEntry).toEqual(false);
+	});
+});
+
 describe("requireDependency", () => {
 	test("throws error if dependencyField does not exist", () => {
 		expect(() => {

--- a/packages/package-json/test/lib/changelog/message-formatters.test.js
+++ b/packages/package-json/test/lib/changelog/message-formatters.test.js
@@ -129,3 +129,15 @@ describe("requireScript", () => {
 		);
 	});
 });
+
+describe("removeScript", () => {
+	test("returns a correctly formatted message", () => {
+		expect(
+			messageFormatters.removeScript({
+				meta: {
+					stage: "test"
+				}
+			})
+		).toEqual("Removed script for stage 'test'");
+	});
+});

--- a/packages/package-json/test/lib/changelog/message-formatters.test.js
+++ b/packages/package-json/test/lib/changelog/message-formatters.test.js
@@ -124,9 +124,7 @@ describe("requireScript", () => {
 					stage: "start"
 				}
 			})
-		).toEqual(
-			"Required script for stage 'start' (overwrote existing command)"
-		);
+		).toEqual("Required script for stage 'start' (overwrote existing command)");
 	});
 });
 

--- a/packages/package-json/test/lib/changelog/message-formatters.test.js
+++ b/packages/package-json/test/lib/changelog/message-formatters.test.js
@@ -54,6 +54,16 @@ describe("setField", () => {
 	});
 });
 
+describe("removeField", () => {
+	test("returns a correctly formatted message", () => {
+		expect(
+			messageFormatters.removeField({
+				field: "bugs"
+			})
+		).toEqual("Removed field 'bugs'");
+	});
+});
+
 describe("requireDependency", () => {
 	test("returns a correctly formatted message", () => {
 		expect(


### PR DESCRIPTION
closes #65 and #15.

Adds a removeField and removeScript method.

Sometimes we want to make changes to package.json files where fields or scripts are removed.  Previously this was done in a hacky way so to simplify our code we are adding specific methods to achieve these changes.