### PR TITLE
Update CODEOWNERS to use email

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
 # See https://help.github.com/articles/about-code-owners/ for more information
 # about this file.
 
-*       @simonplend
+*       simon.plenderleith@ft.com


### PR DESCRIPTION
This is now is in line with the recommendations in the https://github.com/Financial-Times/next/wiki/Creating-New-Apps wiki page.