### PR TITLE
Revise CircleCI executor name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 executors:
-  circleci-node-12:
+  circleci-node:
     docker:
       - image: circleci/node:12
     working_directory: ~/project/build
@@ -70,7 +70,7 @@ references:
 jobs:
 
   build:
-    executor: circleci-node-12
+    executor: circleci-node
     steps:
       - checkout
       - *restore_cache_root
@@ -82,7 +82,7 @@ jobs:
             - build
 
   test:
-    executor: circleci-node-12
+    executor: circleci-node
     steps:
       - *attach_workspace
       - run:
@@ -90,7 +90,7 @@ jobs:
           command: npm test
 
   publish:
-    executor: circleci-node-12
+    executor: circleci-node
     steps:
       - *attach_workspace
       - run:


### PR DESCRIPTION
References should be version agnostic so as not to cause confusion about which value actually applies the Node upgrade.