### PR TITLE
CPP-442 Upgrade GitHub repos from master to main

### DIFF
--- a/packages/git/examples/get-central-branch.js
+++ b/packages/git/examples/get-central-branch.js
@@ -3,7 +3,7 @@ const { getCentralBranch } = require('../src');
 async function main() {
     try {
         await getCentralBranch({
-            remoteUrl: 'git@github.com:Financial-Times/next-health.git',
+            remoteUrl: 'git@github.com:org/repository.git',
         });
     } catch (err) {
         // eslint-disable-next-line no-console

--- a/packages/git/examples/get-central-branch.js
+++ b/packages/git/examples/get-central-branch.js
@@ -1,0 +1,14 @@
+const { getCentralBranch } = require('../src');
+
+async function main() {
+    try {
+        await getCentralBranch({
+            remoteUrl: 'git@github.com:Financial-Times/next-health.git',
+        });
+    } catch (err) {
+        // eslint-disable-next-line no-console
+        console.error(err.message);
+    }
+}
+
+main();

--- a/packages/git/src/helpers/construct-dugite-exec-args.js
+++ b/packages/git/src/helpers/construct-dugite-exec-args.js
@@ -9,7 +9,7 @@
  * ```javascript
  * constructDugiteExecArgs({
  *     command: "clone",
- *     options: { "--origin": "origin", "--branch": "master" },
+ *     options: { "--origin": "origin", "--branch": "main" },
  *     positional: [ "git@github.com:org/repository.git", "/tmp/repo" ]
  * })
  * ```

--- a/packages/git/src/index.js
+++ b/packages/git/src/index.js
@@ -182,6 +182,41 @@ async function listBranches({ workingDirectory = defaults.workingDirectory, remo
 }
 
 /**
+ * Get central branch
+ *
+ * @see https://git-scm.com/docs/git-remote
+ *
+ * @param {object} options
+ * @param {boolean} options.remoteUrl - Repository's remote url
+ * @returns {string}
+ */
+async function getCentralBranch({ remoteUrl } = {}) {
+    try {
+        assert(remoteUrl && typeof remoteUrl === 'string', 'remoteUrl must be a string');
+    } catch (err) {
+        throw new Error(`InvalidOptions: ${err.message}`);
+    }
+
+    const dugiteExecArgs = constructDugiteExecArgs({
+        command: 'remote',
+        options: {},
+        positional: ['show', remoteUrl,],
+    })
+
+    const dugiteExecResult = await GitProcess.exec(
+        dugiteExecArgs,
+    )
+
+    handleDugiteExecResult({ dugiteExecResult, dugiteExecArgs })
+
+    return dugiteExecResult.stdout
+        .split('\n')
+        .find(line => line.includes('HEAD branch:'))
+        .replace('HEAD branch: ', '')
+        .trim()
+}
+
+/**
  * Add file contents to the index.
  *
  * @see https://git-scm.com/docs/git-add
@@ -366,6 +401,7 @@ module.exports = {
     createBranch,
     checkoutBranch,
     listBranches,
+    getCentralBranch,
     deleteBranch,
     add,
     rm,

--- a/packages/git/test/helpers/construct-dugite-exec-args.test.js
+++ b/packages/git/test/helpers/construct-dugite-exec-args.test.js
@@ -60,14 +60,14 @@ describe('`constructDugiteExecArgs` returns the correct array for any combinatio
         ]);
     });
 
-    test('command: "push"; positional: "origin", "master"', () => {
+    test('command: "push"; positional: "origin", "main"', () => {
         const dugiteExecArgs = constructDugiteExecArgs({
             command: 'push',
-            positional: ['origin', 'master']
+            positional: ['origin', 'main']
         });
 
         expect(dugiteExecArgs).toEqual([
-            'push', 'origin', 'master'
+            'push', 'origin', 'main'
         ]);
     });
 

--- a/packages/git/test/list-branches.test.js
+++ b/packages/git/test/list-branches.test.js
@@ -10,7 +10,7 @@ describe('`listBranches` method returns parsed command output when given valid o
 
     beforeAll(() => {
         GitProcess.exec.mockResolvedValue({
-            stdout: `* master
+            stdout: `* main
   branch1
   branch2
 `,
@@ -22,7 +22,7 @@ describe('`listBranches` method returns parsed command output when given valid o
     test('no args', async () => {
         await expect(
             listBranches({})
-        ).resolves.toEqual(['master', 'branch1', 'branch2']);
+        ).resolves.toEqual(['main', 'branch1', 'branch2']);
     });
 
     test('workingDirectory', async () => {
@@ -30,7 +30,7 @@ describe('`listBranches` method returns parsed command output when given valid o
             listBranches({
                 workingDirectory: '/tmp/repository'
             })
-        ).resolves.toEqual(['master', 'branch1', 'branch2']);
+        ).resolves.toEqual(['main', 'branch1', 'branch2']);
     });
 
     test('remote', async () => {
@@ -38,7 +38,7 @@ describe('`listBranches` method returns parsed command output when given valid o
             listBranches({
                 remote: true
             })
-        ).resolves.toEqual(['master', 'branch1', 'branch2']);
+        ).resolves.toEqual(['main', 'branch1', 'branch2']);
     });
 
 });

--- a/packages/package-json/package.json
+++ b/packages/package-json/package.json
@@ -10,11 +10,11 @@
     "package.json"
   ],
   "repository": {
-    "type" : "git",
-    "url" : "https://github.com/financial-times/tooling-helpers.git",
+    "type": "git",
+    "url": "https://github.com/financial-times/tooling-helpers.git",
     "directory": "packages/package-json"
   },
-  "homepage": "https://github.com/Financial-Times/tooling-helpers/blob/master/packages/package-json/README.md",
+  "homepage": "https://github.com/Financial-Times/tooling-helpers/blob/HEAD/packages/package-json/README.md",
   "author": "",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
[Ticket CPP-442 Upgrade GitHub repos from `master` to `main`](https://financialtimes.atlassian.net/browse/CPP-442)<br/><br/>As an organisation we are moving away from the usage of `master` as a central branch and switching it to `main`, this is to avoid using unnecessary language that can be offensive. This PR is for making those changes.

There was also a `getCentralBranch ` added. This command helps projects like nori not assume that `master` is the central branch.