### PR TITLE
Update to npm 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  node: circleci/node@4.6.0
+
 executors:
   circleci-node:
     docker:
@@ -81,6 +84,8 @@ jobs:
     steps:
       - checkout
       - *restore_cache_root
+      - node/install-npm:
+          version: "7"
       - npm-install
       - *create_cache_root
       - persist_to_workspace:

--- a/package.json
+++ b/package.json
@@ -4,11 +4,12 @@
     "postinstall": "athloi exec -- npm install --no-package-lock",
     "test": "npm run unit-test",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
-    "unit-test": "jest"
+    "unit-test": "jest",
+    "preinstall": "npm_config_yes=true npx check-engine"
   },
-  "dependencies": {},
   "devDependencies": {
     "@financial-times/athloi": "^1.0.0-beta.16",
+    "check-engines": "^1.5.0",
     "eslint": "^5.14.1",
     "eslint-config-prettier": "^4.0.0",
     "eslint-plugin-no-only-tests": "^2.1.0",
@@ -16,6 +17,11 @@
     "jest-junit": "^6.2.1"
   },
   "engines": {
-    "node": "12.x"
+    "node": "12.x",
+    "npm": "7.x"
+  },
+  "volta": {
+    "node": "12.22.5",
+    "npm": "7.20.2"
   }
 }

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -16,5 +16,12 @@
     "type": "git",
     "url": "https://github.com/financial-times/tooling-helpers.git",
     "directory": "packages/git"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "engines": {
+    "node": "12.x",
+    "npm": "7.x"
   }
 }

--- a/packages/package-json/package.json
+++ b/packages/package-json/package.json
@@ -19,5 +19,12 @@
   "license": "MIT",
   "devDependencies": {
     "memfs": "^2.15.2"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "engines": {
+    "node": "12.x",
+    "npm": "7.x"
   }
 }


### PR DESCRIPTION
We are moving to npm 7 so we are ready to migrate away from bower. There don't appear to be any breaking changes as part of the migration for this repository, so it was as simple as pinning a new npm version with volta in the root and all of `packages`'s subdirectories (you can also update your npm globally to test the changes) and making sure CircleCI uses the right npm version too. We have added a `preinstall` script to the root `package.json` that will make sure that npm 7 is selected when running an install.