### PR TITLE
Don't force dependents to use npm 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "npm run unit-test",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
     "unit-test": "jest",
-    "preinstall": "npm_config_yes=true npx check-engine"
+    "preinstall": "[[ \"$INIT_CWD\" != \"$PWD\" ]] || npm_config_yes=true npx check-engine"
   },
   "devDependencies": {
     "@financial-times/athloi": "^1.0.0-beta.16",


### PR DESCRIPTION
The `check-engine` script we were using to enforce npm 7 usage when developing locally was also being run when the package was installed by other consumers, causing the installation to fail if they were using an npm version other than 7. This is an unnecessarily restrictive requirement which would mean the npm 7 update was a breaking change -- not our intention. Instead, only run the version check when installing the project directly, not when it's installed as a dependency.