### PR TITLE
Fix issues with engines enforcement

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "test": "npm run unit-test",
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
     "unit-test": "jest",
-    "preinstall": "[[ \"$INIT_CWD\" != \"$PWD\" ]] || npm_config_yes=true npx check-engine"
+    "preinstall": "[ \"$INIT_CWD\" != \"$PWD\" ] || npm_config_yes=true npx check-engine"
   },
   "devDependencies": {
     "@financial-times/athloi": "^1.0.0-beta.16",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "engines": {
     "node": "12.x",
-    "npm": "7.x"
+    "npm": "7.x || 8.x"
   },
   "volta": {
     "node": "12.22.5",


### PR DESCRIPTION
Two changes to enforcing the right version of node and npm with `check-engines`:

1. Improve compatibility of check-engines guard: some shells in use (particularly in our CI and build images) do not support the non-POSIX `[[` command, so use the more portable `[` built-in instead.
2. Allow npm 8: the only breaking change in npm8 is dropping support for `node<12`, but we already require `node@12` so this doesn't affect us and will allow for newer npm versions to be used.