### PR TITLE
CPP-702 Fix cannot read property 'execTask' of undefined

### DIFF
--- a/packages/git/src/index.js
+++ b/packages/git/src/index.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const { GitProcess } = require('dugite');
-const dugiteExec = GitProcess.exec;
+const dugiteExec = GitProcess.exec.bind(GitProcess)
 
 const constructDugiteExecArgs = require('./helpers/construct-dugite-exec-args');
 const defaults = require('./helpers/defaults');


### PR DESCRIPTION
```
TypeError: Cannot read property 'execTask' of undefined
    at exec (/Users/serena.chan/Desktop/repos/next-static/node_modules/dugite/build/lib/git-process.js:58:21)
    at Object.clone (/Users/serena.chan/Desktop/repos/next-static/node_modules/@financial-times/git/src/index.js:45:36)
    at /Users/serena.chan/Desktop/repos/next-static/node_modules/nori/src/commands/clone.js:26:10
```
The above issue was happening because when we assign a function of an object to a variable, the function in the variable loses their awareness of 'this'. It [also happens to be running in strict mode, so 'this' is undefined ](https://dmitripavlutin.com/gentle-explanation-of-this-in-javascript/#22-this-in-a-function-invocation-strict-mode)and therefore 'execTask' is undefined. 
Binding the function to the right context allows it to be aware of the scope of 'this' and fixes the issue.